### PR TITLE
Add AppDrawer, MyChargers and MyBookings screen

### DIFF
--- a/lib/components/app_drawer.dart
+++ b/lib/components/app_drawer.dart
@@ -1,0 +1,41 @@
+import 'package:charg_ev/services/auth.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+class AppDrawer extends StatelessWidget {
+  AppDrawer({Key key}) : super(key: key);
+
+  final AuthService _auth = AuthService();
+
+  @override
+  Widget build(BuildContext context) {
+    final User user = Provider.of<User>(context);
+
+    return Drawer(
+        child: ListView(
+      children: [
+        DrawerHeader(
+            child: Text('Hello, ${user.uid}', style: TextStyle(fontSize: 30))),
+        ListTile(
+            leading: Icon(Icons.calendar_today),
+            title: Text('View My Bookings'),
+            onTap: () {
+              Navigator.pushNamed(context, '/my_bookings');
+            }),
+        ListTile(
+          leading: Icon(Icons.ev_station),
+          title: Text('Manage Chargers'),
+          onTap: () {
+            Navigator.pushNamed(context, '/my_chargers');
+          },
+        ),
+        ListTile(
+          leading: Icon(Icons.input),
+          title: Text('Sign Out'),
+          onTap: _auth.signOut,
+        ),
+      ],
+    ));
+  }
+}

--- a/lib/components/booking_tile.dart
+++ b/lib/components/booking_tile.dart
@@ -1,0 +1,52 @@
+import 'package:charg_ev/models/booking.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:duration/duration.dart';
+
+class BookingTile extends StatelessWidget {
+  const BookingTile({Key key, this.booking}) : super(key: key);
+
+  final Booking booking;
+
+  @override
+  Widget build(BuildContext context) {
+    DateFormat dateFormatterA = DateFormat.yMMMd("en_SG").addPattern('jm', ', ');
+    DateFormat dateFormatterB = DateFormat.jm("en_SG");
+
+    return Padding(
+        padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
+        child: Column(children: [
+          Divider(
+            thickness: 1,
+          ),
+          ListTile(
+            title: Text(
+              booking.chargerLocationName,
+              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+            ),
+            subtitle: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(height: 10),
+                Text(
+                    'From ${dateFormatterA.format(booking.startTime)} to ${dateFormatterB.format(booking.endTime)}\n(${prettyDuration(booking.duration, tersity: DurationTersity.minute)})',
+                    style: TextStyle(fontSize: 16)),
+                RichText(
+                  text: TextSpan(
+                    style: DefaultTextStyle.of(context).style,
+                    children: [
+                      TextSpan(
+                          text: 'Amount paid: ',
+                          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+                      TextSpan(
+                          text:
+                              '${NumberFormat.currency(name: 'SGD').format(booking.price)}')
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          )
+        ]));
+  }
+}

--- a/lib/components/my_charger_tile.dart
+++ b/lib/components/my_charger_tile.dart
@@ -1,0 +1,87 @@
+import 'package:charg_ev/models/charger.dart';
+import 'package:flutter/material.dart';
+
+class MyChargerTile extends StatelessWidget {
+  const MyChargerTile({Key key, this.charger}) : super(key: key);
+
+  final Charger charger;
+
+  @override
+  Widget build(BuildContext context) {
+
+    // fetch dimensions of phone
+    Size size = MediaQuery.of(context).size;
+
+    return Container(
+      width: size.width,
+      padding: EdgeInsets.fromLTRB(16, 8, 16, 16),
+      child: InkWell(
+        onTap: (){},
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.start,
+          children: [
+            Expanded(
+              flex: 6,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    charger.nickname,
+                    style: TextStyle(
+                      fontSize: 24,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.black,
+
+                    ),
+                  ),
+                  Text(
+                    charger.location,
+                    style: TextStyle(
+                      fontSize: 15,
+                      color: Colors.black,
+                    ),
+                  ),
+                  SizedBox(height: size.height * 0.01,),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        "SGD ${charger.rate.toStringAsPrecision(2)}",
+                        style: TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.black,
+                        ),
+                      ),
+                      SizedBox(width: size.width * 0.005,),
+                      Text(
+                        "/ kWh",
+                        style: TextStyle(
+                          fontSize: 15,
+                          color: Colors.grey[600],
+                        ),
+                      ),
+                    ],
+                  ),
+                  Text(
+                    "${charger.available} / ${charger.total} chargers available (${charger.wattage} kW)",
+                    style: TextStyle(
+                      fontSize: 15,
+                      color: Colors.black,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              flex: 1,
+              child: charger.type == 1? Image.asset('assets/Type 1.jpg',): Image.asset('assets/Type 2.jpg',),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,21 +2,21 @@ import 'package:charg_ev/screens/wrapper.dart';
 import 'package:charg_ev/services/auth.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:provider/provider.dart';
 import 'package:firebase_core/firebase_core.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp();
+  await initializeDateFormatting('en_SG');
 
   runApp(StreamProvider<User>.value(
     value: AuthService().user,
     initialData: null,
     child: MaterialApp(
       initialRoute: '/',
-      routes: {
-        '/': (context) => Wrapper()
-      },
+      routes: {'/': (context) => Wrapper()},
     ),
   ));
 }

--- a/lib/models/booking.dart
+++ b/lib/models/booking.dart
@@ -1,0 +1,23 @@
+class Booking {
+
+  String chargerId;
+  String chargerLocationName;
+  DateTime startTime;
+  DateTime endTime;
+  String user;
+  double price;
+  DateTime creationDate;
+
+  Duration get duration {
+    return endTime.difference(startTime);
+  }
+
+  Booking(
+      {this.chargerId,
+      this.startTime,
+      this.endTime,
+      this.user,
+      this.chargerLocationName,
+      this.price,
+      this.creationDate});
+}

--- a/lib/models/charger.dart
+++ b/lib/models/charger.dart
@@ -1,13 +1,23 @@
 // class for information on charging station
 
-class Charger{
-
+class Charger {
   String location;
   double rate;
   int available;
   int total;
   int wattage;
   int type;
+  String uid; //owner
+  String nickname;
 
-  Charger({this.location, this.rate, this.available, this.total, this.wattage, this.type});
+  Charger(
+      {this.location,
+      this.rate,
+      this.available,
+      this.total,
+      this.wattage,
+      this.type,
+      this.uid,
+      this.nickname = 'Charger Name'
+});
 }

--- a/lib/screens/my_bookings.dart
+++ b/lib/screens/my_bookings.dart
@@ -1,0 +1,70 @@
+import 'package:charg_ev/components/app_drawer.dart';
+import 'package:charg_ev/components/booking_tile.dart';
+import 'package:charg_ev/components/welcome_appbar.dart';
+import 'package:charg_ev/models/booking.dart';
+import 'package:charg_ev/services/database.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+// List<Booking> testBookings = [
+//   Booking(chargerId: '1', chargerLocationName: '5A Dunbar Walk', startTime: DateTime.now(), endTime: DateTime.now(), price: 5.6, user: 'hello'),
+//   Booking(chargerId: '2', chargerLocationName: '100 Sengkang Drive', startTime: DateTime.now(), endTime: DateTime.now(), price: 5.2, user: 'hello'),
+//   Booking(chargerId: '1', chargerLocationName: '5A Dunbar Walk', startTime: DateTime.now(), endTime: DateTime.now(), price: 5.6, user: 'hello'),
+//   Booking(chargerId: '2', chargerLocationName: '100 Sengkang Drive', startTime: DateTime.now(), endTime: DateTime.now(), price: 5.2, user: 'hello'),
+//   Booking(chargerId: '1', chargerLocationName: '5A Dunbar Walk', startTime: DateTime.now(), endTime: DateTime.now(), price: 5.6, user: 'hello'),
+//   Booking(chargerId: '2', chargerLocationName: '100 Sengkang Drive', startTime: DateTime.now(), endTime: DateTime.now(), price: 5.2, user: 'hello'),
+//   Booking(chargerId: '1', chargerLocationName: '5A Dunbar Walk', startTime: DateTime.now(), endTime: DateTime.now(), price: 5.6, user: 'hello'),
+//   Booking(chargerId: '2', chargerLocationName: '100 Sengkang Drive', startTime: DateTime.now(), endTime: DateTime.now(), price: 5.2, user: 'hello'),    
+// ];
+
+class MyBookings extends StatelessWidget {
+  const MyBookings({Key key}) : super(key: key);
+
+  Widget build(BuildContext context) {
+    final user = Provider.of<User>(context);
+
+    return Scaffold(
+      drawer: AppDrawer(),
+      body: SafeArea(
+        child: Column(
+          children: [
+            WelcomeAppBar(user.uid),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(8.0, 16.0, 8.0, 0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
+                      child: Text('My Bookings', style: TextStyle(fontSize: 20, fontWeight: FontWeight.w300)),
+                    ),
+                    StreamBuilder<List<Booking>>(
+                        stream: DatabaseService(uid: user.uid).bookingList,
+                        builder: (context, snapshot) {
+                          List<Booking> bookings =
+                              snapshot.hasData ? snapshot.data : [];
+            
+                          return Expanded(
+                            child: ListView.builder(
+                                shrinkWrap: true,
+                                itemCount: bookings.length, //testBookings.length,
+                                itemBuilder: (context, index) {
+                                  return BookingTile( //booking: testBooking
+                                    booking: bookings[index]
+                                  
+                                  );
+                                }),
+                          );
+                        }),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/my_chargers.dart
+++ b/lib/screens/my_chargers.dart
@@ -1,0 +1,70 @@
+import 'package:charg_ev/components/app_drawer.dart';
+import 'package:charg_ev/components/my_charger_tile.dart';
+import 'package:charg_ev/components/welcome_appbar.dart';
+import 'package:charg_ev/models/charger.dart';
+import 'package:charg_ev/services/database.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+// List<Charger> testChargers = [
+//   Charger(location: 'Greenfield Terrace', rate: 0.20, available: 2, total: 5, wattage: 10, type: 1),
+//   Charger(location: 'Telok Kurau Lorong J', rate: 0.20, available: 2, total: 2, wattage: 7, type: 2),
+//   Charger(location: 'Greenfield Lane', rate: 0.20, available: 3, total: 15, wattage: 10, type: 1),
+//   Charger(location: '2 Frankel Avenue', rate: 0.20, available: 10, total: 15, wattage: 8, type: 2),
+//   Charger(location: '256 East Coast Road', rate: 0.20, available: 3, total: 7, wattage: 7, type: 1),
+//   Charger(location: '6 Simei Ave', rate: 0.20, available: 2, total: 2, wattage: 15, type: 2),
+//   Charger(location: '36 Bedok Road', rate: 0.20, available: 6, total: 7, wattage: 8, type: 2),
+//   Charger(location: '59 Pasir Ris Drive', rate: 0.20, available: 3, total: 7, wattage: 10, type: 1),
+// ];
+
+class MyChargers extends StatelessWidget {
+  const MyChargers({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final user = Provider.of<User>(context);
+
+    return Scaffold(
+      drawer: AppDrawer(),
+      body: SafeArea(
+        child: Column(
+          children: [
+            WelcomeAppBar(user.uid),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(8.0, 16.0, 8.0, 0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
+                      child: Text('My Chargers',
+                          style: TextStyle(
+                              fontSize: 20, fontWeight: FontWeight.w300)),
+                    ),
+                    StreamBuilder<List<Charger>>(
+                        stream: DatabaseService(uid: user.uid).chargerList,
+                        builder: (context, snapshot) {
+                          List<Charger> chargers =
+                              snapshot.hasData ? snapshot.data : [];
+            
+                          return Expanded(
+                            child: ListView.builder(
+                                itemCount: chargers.length, //testChargers.length,
+                                itemBuilder: (context, index) {
+                                  return MyChargerTile( //testChargers[index]);
+                                    charger: chargers[index]); 
+                                }),
+                          );
+                        }),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/wrapper.dart
+++ b/lib/screens/wrapper.dart
@@ -2,6 +2,8 @@ import 'package:charg_ev/screens/authentication/authenticate.dart';
 import 'package:charg_ev/screens/booking.dart';
 import 'package:charg_ev/screens/charger_category.dart';
 import 'package:charg_ev/screens/charger_selection.dart';
+import 'package:charg_ev/screens/my_bookings.dart';
+import 'package:charg_ev/screens/my_chargers.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -23,6 +25,8 @@ class Wrapper extends StatelessWidget {
             '/charger_selection': (context) => ChargerSelection(),
             '/booking': (context) => Booking(),
             '/confirm_booking': (context) => ConfirmBooking(),
+            '/my_bookings': (context) => MyBookings(),
+            '/my_chargers': (context) => MyChargers(),
           });
   }
 }

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -1,17 +1,18 @@
+import 'package:charg_ev/models/booking.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:charg_ev/models/charger.dart';
 import 'package:intl/intl.dart';
 
 class DatabaseService {
-
   final String uid;
   DatabaseService({this.uid});
 
   // collection reference for userInfo
-  final CollectionReference userCollection = FirebaseFirestore.instance.collection('UserInfo');
+  final CollectionReference userCollection =
+      FirebaseFirestore.instance.collection('UserInfo');
 
   // add charger booking
-  Future addChargerBooking (Charger charger, DateTime datetime) async {
+  Future addChargerBooking(Charger charger, DateTime datetime) async {
     return await userCollection.doc(uid).collection('chargerBooking').add({
       'location': charger.location,
       'rate': charger.rate,
@@ -39,4 +40,38 @@ class DatabaseService {
     });
   }
 
+  //get List of Chargers
+  Stream<List<Charger>> get chargerList {
+    return userCollection.doc(uid).collection('chargers').snapshots()
+        .map((snapshot) => snapshotToChargerList(snapshot));
+  }
+
+  //get List of Bookings
+  Stream<List<Booking>> get bookingList {
+    return userCollection
+        .doc(uid)
+        .collection('bookings')
+        .snapshots() //Stream<QuerySnapShot> => Stream<List<Docs>> => Stream<List<Booking>>
+        .map((snapshot) => snapshotToBookingsList(snapshot));
+  }
+
+  //utility functions
+  List<Booking> snapshotToBookingsList(QuerySnapshot snapshot) {
+    return snapshot.docs.map((doc) => Booking(
+        chargerId: doc.get('chargerId'),
+        startTime: doc.get('startTime'),
+        endTime: doc.get('endTime'),
+        user: uid));
+  }
+
+  List<Charger> snapshotToChargerList(QuerySnapshot snapshot) {
+    return snapshot.docs.map((doc) => Charger(
+        location: doc.get('location'),
+        rate: doc.get('rate'),
+        type: doc.get('type'),
+        wattage: doc.get('wattage'),
+        total: doc.get('total'),
+        available: doc.get('available'),
+        uid: uid));
+  }
 }


### PR DESCRIPTION
MyChargers and MyBookings are two screens that list out a user's
chargers and bookings respectively.

+ Allow AppDrawer to navigate to MyBookings and MyChargers
+ Add functions in database service file to expose streams that return a
  user's list of bookings and chargers at any given point in time
+ MyBookings and MyChargers screens will listen to said streams and
  build a list based on snapshots returned from stream.

+ Add `models/booking.dart`
+ Add nickname and uid field to `models/charger.dart`
	-nickname field will allow charger owners to identify their own chargers, to be used in `MyChargerTile`
	-default nickname is `"Charger Name"`

+ Add BookingTile and MyChargerTile
+ Modified main.dart to initialize locale for intl package
+ Modify wrapper.dart to add routes for MyBookings and MyChargers page